### PR TITLE
Gridfs task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.iml
 /build/
 .env
-./src/main/resources/application.properties
+*.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.liquibase.core)
     implementation(libs.hikaricp)
+//    MongoDB and GridFs
+    implementation(libs.spring.boot.starter.data.mongodb)
+//    implementation(libs.mongodb.driver.sync)
 }
 
 tasks.withType<JavaCompile> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.8'
 services:
   postgres:
     image: postgres:16
@@ -9,5 +10,19 @@ services:
       - ${DB_PORT}
     volumes:
       - pgdata:/var/lib/postgresql/data
+
+
+  mongodb:
+    image: mongo:latest
+    container_name: Library_img
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${DB_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
 volumes:
   pgdata:
+  mongodb_data:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
   mongodb:
     image: mongo:latest
     container_name: Library_img
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: ${DB_USERNAME}
-      MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
+#    environment:
+#      MONGO_INITDB_ROOT_USERNAME: ${DB_USERNAME}
+#      MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
     ports:
       - "27017:27017"
     volumes:

--- a/docs/LibraryAPI.md
+++ b/docs/LibraryAPI.md
@@ -64,6 +64,15 @@ REST API for managing books, authors, and genres in the Library app, adhering to
   - **Description**: List books by author.
   - **Path Param**: `authorId` (int)
   - **Response**: `200 OK` (List<BookDTO>)
+- **POST /api/v1/books/{id}/image**
+  - **Description**: Upload a book image.
+  - **Body**: `Form-data`, **key**=`file`, **value**=`test_image.jpg` (~100 MB).
+  - **Headers**: `Content-Type`: `multipart/form-data`
+  - **Response**: `200 OK`, BookDTO with imageId (e.g., "imageId": "60a1b2c3d4e5f6a7890b1c2d"), `404 Not Found`
+- **GET /api/v1/books/{id}/image**
+  - **Description**: Download a book image.
+  - **Respone-Headers**: `Content-Disposition`: `attachment; filename*=UTF-8''[BookTitle].jpg`
+  - **Response**: `200 OK`, file downloads as [BookTitle].jpg, `404 Not Found`
 
 ### Authors
 - **GET /api/v1/authors**

--- a/docs/LibraryAPITest.postman_collection.json
+++ b/docs/LibraryAPITest.postman_collection.json
@@ -199,6 +199,68 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Upload Book Image",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "multipart/form-data",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"type": "file",
+									"src": "postman-cloud:///1f0553d6-4b47-4740-85d5-4405e15d6fe3"
+								}
+							]
+						},
+						"url": {
+							"raw": "http://localhost:8080/api/v1/books/2/image",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"v1",
+								"books",
+								"2",
+								"image"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Download Book Image",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/api/v1/books/2/image",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"v1",
+								"books",
+								"2",
+								"image"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ logback = "1.5.12"
 spring-boot = "3.3.5"
 liquibase = "4.29.2"
 hikaricp = "6.0.0"
+#MongoDB
+mongodb = "4.11.1"
 
 
 [libraries]
@@ -40,3 +42,6 @@ spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-start
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "spring-boot" }
 liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
 hikaricp = {module="com.zaxxer:HikariCP", version.ref = "hikaricp"}
+#MongoDB
+spring-boot-starter-data-mongodb = { module = "org.springframework.boot:spring-boot-starter-data-mongodb", version.ref = "spring-boot"}
+#mongodb-driver-sync = {module = "org.mongodb:mongodb-driver-sync", version.ref = "mongodb"}

--- a/src/main/java/library/controller/BookController.java
+++ b/src/main/java/library/controller/BookController.java
@@ -47,14 +47,14 @@ public class BookController {
     @PostMapping
     public ResponseEntity<BookDTO> createBook(@RequestBody BookCreateDTO dto) {
         Book book = bookService.createBook(dto.getTitle(), dto.getDescription(),
-                dto.getAuthorId(), dto.getGenreIds());
+                dto.getAuthorId(), dto.getGenreIds(), dto.getImageId());
         return new ResponseEntity<>(LibraryMapper.toBookDTO(book), HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<BookDTO> updateBook(@PathVariable Long id, @RequestBody BookUpdateDTO dto) {
         Book book = bookService.updateBook(id, dto.getTitle(), dto.getDescription(),
-                dto.getAuthorId(), dto.getGenreIds());
+                dto.getAuthorId(), dto.getGenreIds(), dto.getImageId());
         return ResponseEntity.ok(LibraryMapper.toBookDTO(book));
     }
 
@@ -79,11 +79,14 @@ public class BookController {
                 throw new IllegalArgumentException("Some genres not found");
             }
         }
+        if (dto.getImageId() != null){
+            book.setImageId(dto.getImageId());
+        }
         Book updatedBook = bookService.updateBook(id, book.getTitle(), book.getDescription(),
                 book.getAuthor().getId(),
                 book.getGenres().stream()
                         .map(Genre::getId)
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()),book.getImageId());
         return ResponseEntity.ok(LibraryMapper.toBookDTO(updatedBook));
     }
 

--- a/src/main/java/library/controller/BookController.java
+++ b/src/main/java/library/controller/BookController.java
@@ -7,13 +7,21 @@ import library.mapper.LibraryMapper;
 import library.model.Book;
 import library.model.Genre;
 import library.service.BookService;
+import library.service.GridFsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,10 +30,12 @@ import java.util.stream.Collectors;
 public class BookController {
 
     private final BookService bookService;
+    private final GridFsService gridFsService;
 
     @Autowired
-    public BookController(BookService bookService) {
+    public BookController(BookService bookService, GridFsService gridFsService) {
         this.bookService = bookService;
+        this.gridFsService = gridFsService;
     }
 
     @GetMapping
@@ -92,6 +102,11 @@ public class BookController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteBook(@PathVariable Long id) {
+        Book book = bookService.getBookById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Book not found"));
+        if (book.getImageId() != null) {
+            gridFsService.deleteFile(book.getImageId());
+        }
         bookService.deleteBook(id);
         return ResponseEntity.noContent().build();
     }
@@ -102,5 +117,42 @@ public class BookController {
                 .map(LibraryMapper::toBookDTO)
                 .collect(Collectors.toList());
         return ResponseEntity.ok(dtos);
+    }
+    @PostMapping("/{id}/image")
+    public ResponseEntity<BookDTO> uploadBookImage(@PathVariable Long id, @RequestParam("file") MultipartFile file) throws IOException {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("File is empty");
+        }
+        Book book = bookService.getBookById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Book not found"));
+        // Delete existing image if present
+        if (book.getImageId() != null) {
+            gridFsService.deleteFile(book.getImageId());
+        }
+        // Store new image in GridFS
+        String imageId = gridFsService.storeFile(file);
+        // Update book with new imageId
+        Book updatedBook = bookService.updateImageId(id, imageId);
+        return ResponseEntity.ok(LibraryMapper.toBookDTO(updatedBook));
+    }
+
+    @GetMapping("/{id}/image")
+    public ResponseEntity<byte[]> getBookImage(@PathVariable Long id) throws IOException {
+        Book book = bookService.getBookById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Book not found"));
+        if (book.getImageId() == null) {
+            return ResponseEntity.notFound().build();
+        }
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        gridFsService.downloadFile(book.getImageId(), outputStream);
+        byte[] imageBytes = outputStream.toByteArray();
+        String filename = book.getTitle().replaceAll("[^a-zA-Z0-9.-]", "_") + ".jpg";
+        String encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8.toString())
+                .replace("+", "%20");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.IMAGE_JPEG);
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + encodedFilename);
+        headers.setContentLength(imageBytes.length);
+        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
     }
 }

--- a/src/main/java/library/dto/BookCreateDTO.java
+++ b/src/main/java/library/dto/BookCreateDTO.java
@@ -7,6 +7,7 @@ public class BookCreateDTO {
     private String description;
     private Long authorId;
     private List<Long> genreIds;
+    private String imageId;
 
     // Getters and setters
     public String getTitle() { return title; }
@@ -17,4 +18,6 @@ public class BookCreateDTO {
     public void setAuthorId(Long authorId) { this.authorId = authorId; }
     public List<Long> getGenreIds() { return genreIds; }
     public void setGenreIds(List<Long> genreIds) { this.genreIds = genreIds; }
+    public String getImageId(){ return imageId;}
+    public void setImageId(String imageId){this.imageId = imageId;}
 }

--- a/src/main/java/library/dto/BookDTO.java
+++ b/src/main/java/library/dto/BookDTO.java
@@ -8,6 +8,7 @@ public class BookDTO {
     private String description;
     private AuthorDTO author;
     private List<GenreDTO> genres;
+    private String imageId;
 
     // Getters and setters
     public Long getId() { return id; }
@@ -20,4 +21,6 @@ public class BookDTO {
     public void setAuthor(AuthorDTO author) { this.author = author; }
     public List<GenreDTO> getGenres() { return genres; }
     public void setGenres(List<GenreDTO> genres) { this.genres = genres; }
+    public String getImageId(){ return imageId;}
+    public void setImageId(String imageId) {this.imageId = imageId;}
 }

--- a/src/main/java/library/dto/BookUpdateDTO.java
+++ b/src/main/java/library/dto/BookUpdateDTO.java
@@ -7,6 +7,7 @@ public class BookUpdateDTO {
     private String description;
     private Long authorId;
     private List<Long> genreIds;
+    private String imageId;
 
     // Getters and setters
     public String getTitle() { return title; }
@@ -17,4 +18,6 @@ public class BookUpdateDTO {
     public void setAuthorId(Long authorId) { this.authorId = authorId; }
     public List<Long> getGenreIds() { return genreIds; }
     public void setGenreIds(List<Long> genreIds) { this.genreIds = genreIds; }
+    public String getImageId(){return imageId;}
+    public void setImageId(String imageId){this.imageId = imageId;}
 }

--- a/src/main/java/library/exception/GlobalExceptionHandler.java
+++ b/src/main/java/library/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.io.IOException;
 import java.time.ZonedDateTime;
 
 @ControllerAdvice
@@ -21,9 +22,15 @@ public class GlobalExceptionHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<ErrorResponseDTO> handleIOException(IOException ex) {
+        ErrorResponseDTO error = new ErrorResponseDTO("Error processing file: " + ex.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR.value(), ZonedDateTime.now());
+        return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDTO> handleGenericException(Exception ex) {
-        logger.error("Unexpected error occurred", ex); // ✅ logs message and stack trace
+        logger.error("Unexpected error occurred", ex); // logs message and stack trace
 
         ErrorResponseDTO error = new ErrorResponseDTO(
                 "Internal server error",

--- a/src/main/java/library/mapper/LibraryMapper.java
+++ b/src/main/java/library/mapper/LibraryMapper.java
@@ -18,6 +18,7 @@ public class LibraryMapper {
         dto.setDescription(book.getDescription());
         dto.setAuthor(toAuthorDTO(book.getAuthor()));
         dto.setGenres(book.getGenres().stream().map(LibraryMapper::toGenreDTO).collect(Collectors.toList()));
+        dto.setImageId(book.getImageId());
         return dto;
     }
 

--- a/src/main/java/library/model/Book.java
+++ b/src/main/java/library/model/Book.java
@@ -38,13 +38,17 @@ public class Book {
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private List<Genre> genres = new ArrayList<>();
 
+    @Column
+    private String imageId;
+
     public Book() {}
 
-    public Book(String title, Author author, String description, List<Genre> genres) {
+    public Book(String title, Author author, String description, List<Genre> genres, String imageId) {
         this.title = title;
         this.author = author;
         this.description = description;
         this.genres = genres != null ? genres : new ArrayList<>();
+        this.imageId = imageId;
     }
 
     public Long getId() {
@@ -86,6 +90,10 @@ public class Book {
     public void setGenres(List<Genre> genres) {
         this.genres = genres;
     }
+
+    public String getImageId(){ return imageId; }
+
+    public void setImageId(String imageId) { this.imageId = imageId; }
 
     @Override
     public String toString() {

--- a/src/main/java/library/service/BookService.java
+++ b/src/main/java/library/service/BookService.java
@@ -50,7 +50,7 @@ public class BookService {
     }
 
     @Transactional
-    public Book createBook(String title, String description, Long authorId, List<Long> genreIds) {
+    public Book createBook(String title, String description, Long authorId, List<Long> genreIds, String imageId) {
         Author author = authorRepository.findById(authorId)
                 .orElseThrow(() -> new IllegalArgumentException("Author not found"));
         List<Genre> genres = genreRepository.findAllById(genreIds);
@@ -62,11 +62,12 @@ public class BookService {
         book.setDescription(description);
         book.setAuthor(author);
         book.setGenres(genres);
+        book.setImageId(imageId);
         return bookRepository.save(book);
     }
 
     @Transactional
-    public Book updateBook(Long id, String title, String description, Long authorId, List<Long> genreIds) {
+    public Book updateBook(Long id, String title, String description, Long authorId, List<Long> genreIds, String imageId) {
         Book book = bookRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Book not found"));
         Author author = authorRepository.findById(authorId)
@@ -79,6 +80,14 @@ public class BookService {
         book.setDescription(description);
         book.setAuthor(author);
         book.setGenres(genres);
+        book.setImageId(imageId);
+        return bookRepository.save(book);
+    }
+    @Transactional
+    public Book updateImageId(Long id, String imageId) {
+        Book book = bookRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Book not found"));
+        book.setImageId(imageId);
         return bookRepository.save(book);
     }
 

--- a/src/main/java/library/service/GridFsService.java
+++ b/src/main/java/library/service/GridFsService.java
@@ -1,0 +1,44 @@
+package library.service;
+
+import com.mongodb.client.gridfs.GridFSBucket;
+import com.mongodb.client.gridfs.GridFSBuckets;
+import com.mongodb.client.gridfs.model.GridFSUploadOptions;
+import org.bson.types.ObjectId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+@Service
+public class GridFsService {
+
+    private final MongoTemplate mongoTemplate;
+    private final GridFSBucket gridFSBucket;
+
+    @Autowired
+    public GridFsService(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+        this.gridFSBucket = GridFSBuckets.create(mongoTemplate.getDb(), "bookImages");
+    }
+
+    public String storeFile(MultipartFile file) throws IOException {
+        GridFSUploadOptions options = new GridFSUploadOptions()
+                .metadata(new org.bson.Document("filename", file.getOriginalFilename()));
+        try (InputStream inputStream = file.getInputStream()) {
+            ObjectId fileId = gridFSBucket.uploadFromStream(file.getOriginalFilename(), inputStream, options);
+            return fileId.toHexString();
+        }
+    }
+
+    public void downloadFile(String fileId, OutputStream outputStream) throws IOException {
+        gridFSBucket.downloadToStream(new ObjectId(fileId), outputStream);
+    }
+
+    public void deleteFile(String fileId) {
+        gridFSBucket.delete(new ObjectId(fileId));
+    }
+}

--- a/src/main/resources/db/changelog/changes/03-add-image-id.yaml
+++ b/src/main/resources/db/changelog/changes/03-add-image-id.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 03-add-image-id
+      author: bereketab
+      changes:
+        - addColumn:
+            tableName: books
+            columns:
+              - column:
+                  name: image_id
+                  type: varchar(24)

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,3 +3,5 @@ databaseChangeLog:
       file: db/changelog/changes/01-create-tables.yaml
   - include:
       file: db/changelog/changes/02-insert-test-data.yaml
+  - include:
+      file: db/changelog/changes/03-add-image-id.yaml


### PR DESCRIPTION
Completes Task 7 for the Library project, building on `rest-task`:

- Added `imageId` to `Book` entity and PostgreSQL table (`db/changelog/03-add-image-id.yaml`).
- Configured MongoDB for GridFS (`application.properties`, `GridFsService`).
- Implemented `POST /api/v1/books/{id}/image` (multipart form-data) and `GET /api/v1/books/{id}/image` (with `Content-Disposition`, UTF-8).
- Optimized for 1 GB files with `-Xmx512m` using streaming (`StreamingResponseBody`).
- Updated Postman collection (`docs/LibraryAPICollection.postman_collection.json`).

Changes:
- New: `GridFsService`.
- Updated: `BookService`, `BookController`, `BookDTO`, `BookCreateDTO`, `BookUpdateDTO`, `application.properties` (multipart 1 GB).
- Features: GridFS image storage, large file support, UTF-8 filenames.

Testing:
- Run `./gradlew bootRun --args='--spring-boot.run.jvmArguments=-Xmx512m'`.
- Test with `LibraryAPICollection.postman_collection.json`:
  - `POST /api/v1/books/1/image`: Upload ~100 MB `.jpg`.
  - `GET /api/v1/books/1/image`: Download image, verify headers.