### PR TITLE
Security task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,11 @@ dependencies {
     implementation(libs.hikaricp)
 //    MongoDB and GridFs
     implementation(libs.spring.boot.starter.data.mongodb)
-//    implementation(libs.mongodb.driver.sync)
+//    Spring Security
+    implementation(libs.spring.boot.starter.security)
+    implementation(libs.jjwt.api)
+    runtimeOnly(libs.jjwt.impl)
+    runtimeOnly(libs.jjwt.jackson)
 }
 
 tasks.withType<JavaCompile> {

--- a/docs/LibraryAPI.md
+++ b/docs/LibraryAPI.md
@@ -125,7 +125,25 @@ REST API for managing books, authors, and genres in the Library app, adhering to
   - **Description**: Delete a genre.
   - **Path Param**: `id` (int)
   - **Response**: `204 No Content`, `404 Not Found`
-
+### Authentication
+- **POST /api/v1/register**
+  - **Description**: Register User with default role 'User'.
+  - **Body**: 
+  - ```json
+    {"username": "username", "password": "password"}
+    ```
+  - **Response**: `200 OK`: User registered successfully, `400 Bad Request`: Invalid input or username already exists.
+- **POST /api/v1/login**
+  - **Description**: Authenticates a user and returns a JWT in the Authorization header.
+  - **Body**:
+  - ```json
+    {"username": "username", "password": "password"}
+    ```
+  - **Response**: `200 OK`: Login successful, JWT in Authorization header., `401 Unauthorized`: Bad credentials.
+- **GET /api/v1/admin/test**
+  - **Description**: Admin-only endpoint to test ROLE_ADMIN access. Requires JWT authentication.
+  - **Headers**: `Authorization: Bearer <jwt_token>` 
+  - **Response**: `200 OK`: Access granted for users with ROLE_ADMIN, `401 Unauthorized`: No or invalid JWT provided., `403 Forbidden`: User lacks ROLE_ADMIN (e.g., ROLE_USER).
 ## Models
 - **BookDTO**:
   ```json

--- a/docs/LibraryAPITest.postman_collection
+++ b/docs/LibraryAPITest.postman_collection
@@ -12,6 +12,16 @@
 				{
 					"name": "Get All Books",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{Token}}",
+									"type": "string"
+								}
+							]
+						},
 						"method": "GET",
 						"header": [],
 						"url": {
@@ -545,6 +555,125 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Auth",
+			"item": [
+				{
+					"name": "Register",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"username\": \"testuser\", \"password\": \"testpass\"}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/api/v1/register",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"v1",
+								"register"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{Token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"username\": \"testuser\", \"password\": \"testpass\"}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/api/v1/login",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"v1",
+								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "AdminTest",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/api/v1/admin/test",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"v1",
+								"admin",
+								"test"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"variable": [
+		{
+			"key": "Bearer <token>",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "Token",
+			"value": "",
+			"type": "default"
 		}
 	]
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,8 @@ logback = "1.5.12"
 spring-boot = "3.3.5"
 liquibase = "4.29.2"
 hikaricp = "6.0.0"
-#MongoDB
-mongodb = "4.11.1"
+#JWT
+jwt = "0.12.6"
 
 
 [libraries]
@@ -44,4 +44,8 @@ liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liqui
 hikaricp = {module="com.zaxxer:HikariCP", version.ref = "hikaricp"}
 #MongoDB
 spring-boot-starter-data-mongodb = { module = "org.springframework.boot:spring-boot-starter-data-mongodb", version.ref = "spring-boot"}
-#mongodb-driver-sync = {module = "org.mongodb:mongodb-driver-sync", version.ref = "mongodb"}
+#Spring Security
+spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security", version.ref = "spring-boot"}
+jjwt-api = {module = "io.jsonwebtoken:jjwt-api", version.ref = "jwt"}
+jjwt-impl = {module = "io.jsonwebtoken:jjwt-impl", version.ref = "jwt"}
+jjwt-jackson = {module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jwt"}

--- a/src/main/java/library/Application.java
+++ b/src/main/java/library/Application.java
@@ -2,10 +2,16 @@ package library;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
 public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
+//    public static void main(String[] args) {
+//        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+//        System.out.println("user:password -> " + encoder.encode("password"));
+//        System.out.println("admin:admin -> " + encoder.encode("admin"));
+//    }
 }

--- a/src/main/java/library/controller/AdminController.java
+++ b/src/main/java/library/controller/AdminController.java
@@ -1,0 +1,18 @@
+package library.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+
+    @GetMapping("/test")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> testAdminEndpoint() {
+        return ResponseEntity.ok("Admin endpoint accessed successfully");
+    }
+}

--- a/src/main/java/library/controller/AuthController.java
+++ b/src/main/java/library/controller/AuthController.java
@@ -1,0 +1,61 @@
+package library.controller;
+
+import library.dto.LoginRequestDTO;
+import library.dto.RegisterRequestDTO;
+import library.model.User;
+import library.repository.UserRepository;
+import library.security.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Autowired
+    public AuthController(AuthenticationManager authenticationManager, UserRepository userRepository,
+                          PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<String> register(@RequestBody RegisterRequestDTO request) {
+        if (userRepository.findByUsername(request.getUsername()).isPresent()) {
+            return ResponseEntity.badRequest().body("Username already exists");
+        }
+        User user = new User();
+        user.setUsername(request.getUsername());
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setEnabled(true);
+        userRepository.save(user);
+        return ResponseEntity.ok("User registered successfully");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody LoginRequestDTO request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        String token = jwtUtil.generateToken(userDetails.getUsername());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .body("Login successful");
+    }
+}
+
+

--- a/src/main/java/library/dto/ErrorResponseDTO.java
+++ b/src/main/java/library/dto/ErrorResponseDTO.java
@@ -5,16 +5,16 @@ import java.time.ZonedDateTime;
 public class ErrorResponseDTO {
     private String error;
     private int status;
-    private ZonedDateTime timestamp;
 
-    public ErrorResponseDTO(String error, int status, ZonedDateTime timestamp) {
+
+    public ErrorResponseDTO(String error, int status) {
         this.error = error;
         this.status = status;
-        this.timestamp = timestamp;
+
     }
 
     // Getters
     public String getError() { return error; }
     public int getStatus() { return status; }
-    public ZonedDateTime getTimestamp() { return timestamp; }
+
 }

--- a/src/main/java/library/dto/LoginRequestDTO.java
+++ b/src/main/java/library/dto/LoginRequestDTO.java
@@ -1,0 +1,12 @@
+package library.dto;
+
+public class LoginRequestDTO {
+    private String username;
+    private String password;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}
+

--- a/src/main/java/library/dto/RegisterRequestDTO.java
+++ b/src/main/java/library/dto/RegisterRequestDTO.java
@@ -1,0 +1,14 @@
+package library.dto;
+
+public class RegisterRequestDTO {
+
+        private String username;
+        private String password;
+
+        public String getUsername() { return username; }
+        public void setUsername(String username) { this.username = username; }
+        public String getPassword() { return password; }
+        public void setPassword(String password) { this.password = password; }
+
+
+}

--- a/src/main/java/library/exception/GlobalExceptionHandler.java
+++ b/src/main/java/library/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponseDTO> handleIllegalArgumentException(IllegalArgumentException ex) {
-        ErrorResponseDTO error = new ErrorResponseDTO(ex.getMessage(), HttpStatus.BAD_REQUEST.value(), ZonedDateTime.now());
+        ErrorResponseDTO error = new ErrorResponseDTO(ex.getMessage(), HttpStatus.BAD_REQUEST.value());
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IOException.class)
     public ResponseEntity<ErrorResponseDTO> handleIOException(IOException ex) {
-        ErrorResponseDTO error = new ErrorResponseDTO("Error processing file: " + ex.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR.value(), ZonedDateTime.now());
+        ErrorResponseDTO error = new ErrorResponseDTO("Error processing file: " + ex.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR.value());
         return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -36,22 +36,20 @@ public class GlobalExceptionHandler {
 
         ErrorResponseDTO error = new ErrorResponseDTO(
                 "Internal server error",
-                HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                ZonedDateTime.now()
+                HttpStatus.INTERNAL_SERVER_ERROR.value()
         );
         return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
     }
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ErrorResponseDTO> handleAuthenticationException(AuthenticationException ex) {
-        ErrorResponseDTO error = new ErrorResponseDTO("Unauthorized: " + ex.getMessage(),HttpStatus.UNAUTHORIZED.value(),
-                ZonedDateTime.now());
+        ErrorResponseDTO error = new ErrorResponseDTO("Unauthorized: " + ex.getMessage(),HttpStatus.UNAUTHORIZED.value());
         return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponseDTO> handleAccessDeniedException(AccessDeniedException ex) {
-        ErrorResponseDTO error = new ErrorResponseDTO("Access denied: " + ex.getMessage(),HttpStatus.FORBIDDEN.value(),
-                ZonedDateTime.now());
+        ErrorResponseDTO error = new ErrorResponseDTO("Access denied: " + ex.getMessage(),HttpStatus.FORBIDDEN.value()
+               );
         return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
     }
 }

--- a/src/main/java/library/exception/GlobalExceptionHandler.java
+++ b/src/main/java/library/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -38,5 +40,18 @@ public class GlobalExceptionHandler {
                 ZonedDateTime.now()
         );
         return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponseDTO> handleAuthenticationException(AuthenticationException ex) {
+        ErrorResponseDTO error = new ErrorResponseDTO("Unauthorized: " + ex.getMessage(),HttpStatus.UNAUTHORIZED.value(),
+                ZonedDateTime.now());
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponseDTO> handleAccessDeniedException(AccessDeniedException ex) {
+        ErrorResponseDTO error = new ErrorResponseDTO("Access denied: " + ex.getMessage(),HttpStatus.FORBIDDEN.value(),
+                ZonedDateTime.now());
+        return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
     }
 }

--- a/src/main/java/library/model/Role.java
+++ b/src/main/java/library/model/Role.java
@@ -1,0 +1,26 @@
+package library.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "roles")
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String role;
+
+    // Getters and setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
+}

--- a/src/main/java/library/model/User.java
+++ b/src/main/java/library/model/User.java
@@ -1,0 +1,36 @@
+package library.model;
+
+import jakarta.persistence.*;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.EAGER)
+    private Set<Role> roles;
+
+    // Getters and setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public Set<Role> getRoles() { return roles; }
+    public void setRoles(Set<Role> roles) { this.roles = roles; }
+}

--- a/src/main/java/library/repository/RoleRepository.java
+++ b/src/main/java/library/repository/RoleRepository.java
@@ -1,0 +1,7 @@
+package library.repository;
+
+import library.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+}

--- a/src/main/java/library/repository/UserRepository.java
+++ b/src/main/java/library/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package library.repository;
+
+import library.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/library/security/CustomUserDetailsService.java
+++ b/src/main/java/library/security/CustomUserDetailsService.java
@@ -1,0 +1,40 @@
+package library.security;
+
+import library.model.User;
+import library.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(),
+                user.getPassword(),
+                user.isEnabled(),
+                true, // accountNonExpired
+                true, // credentialsNonExpired
+                true, // accountNonLocked
+                user.getRoles().stream()
+                        .map(role -> new SimpleGrantedAuthority(role.getRole()))
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/library/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/library/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package library.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Access Denied");
+    }
+}

--- a/src/main/java/library/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/library/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package library.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import library.dto.ErrorResponseDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        System.out.println(">>> JwtAuthenticationEntryPoint CALLED <<<");
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        ErrorResponseDTO error = new ErrorResponseDTO("Unauthorized: " + authException.getMessage(), HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(error));
+    }
+}

--- a/src/main/java/library/security/JwtAuthenticationFilter.java
+++ b/src/main/java/library/security/JwtAuthenticationFilter.java
@@ -30,18 +30,38 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
+
+        String path = request.getServletPath();
+
+        // Skip filtering for public endpoints
+        if (path.equals("/api/v1/login") || path.equals("/api/v1/register")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         String authHeader = request.getHeader("Authorization");
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            String token = authHeader.substring(7);
-            if (jwtUtil.validateToken(token)) {
-                String username = jwtUtil.getUsernameFromToken(token);
-                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+//            chain.doFilter(request, response); // Skip if no/invalid token
+//            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Missing or invalid Authorization header");
+//            return;
+            throw new org.springframework.security.authentication.BadCredentialsException("Missing or invalid Authorization header");
+        }
+
+        String token = authHeader.substring(7);
+        String username = jwtUtil.getUsernameFromToken(token);
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+            if (jwtUtil.validateToken(token, userDetails)) {
                 UsernamePasswordAuthenticationToken authToken =
                         new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authToken);
+            } else {
+                // Invalid token
+//
+                throw new org.springframework.security.authentication.BadCredentialsException("Invalid token");
             }
+            }
+            chain.doFilter(request, response);
         }
-        chain.doFilter(request, response);
-    }
 }

--- a/src/main/java/library/security/JwtAuthenticationFilter.java
+++ b/src/main/java/library/security/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package library.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Autowired
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            if (jwtUtil.validateToken(token)) {
+                String username = jwtUtil.getUsernameFromToken(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken authToken =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/library/security/JwtUtil.java
+++ b/src/main/java/library/security/JwtUtil.java
@@ -1,0 +1,49 @@
+package library.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.function.Function;
+
+@Component
+public class JwtUtil {
+
+    private final Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS512);
+    private final long expirationMs = 3600_000; // 1 hour
+
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String getUsernameFromToken(String token) {
+        return getClaimFromToken(token, Claims::getSubject);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claimsResolver.apply(claims);
+    }
+}

--- a/src/main/java/library/security/SecurityConfig.java
+++ b/src/main/java/library/security/SecurityConfig.java
@@ -1,0 +1,15 @@
+package library.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/library/security/SecurityConfig.java
+++ b/src/main/java/library/security/SecurityConfig.java
@@ -2,14 +2,49 @@ package library.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          AuthenticationConfiguration authenticationConfiguration) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.authenticationConfiguration = authenticationConfiguration;
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/register", "/api/v1/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
     }
 }

--- a/src/main/resources/db/changelog/changes/04-create-users-roles.yaml
+++ b/src/main/resources/db/changelog/changes/04-create-users-roles.yaml
@@ -1,0 +1,54 @@
+databaseChangeLog:
+  - changeSet:
+      id: 04-create-users-roles
+      author: bereketab
+      changes:
+        - createTable:
+            tableName: users
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: username
+                  type: varchar(50)
+                  constraints:
+                    unique: true
+                    nullable: false
+              - column:
+                  name: password
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: enabled
+                  type: boolean
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+        - createTable:
+            tableName: roles
+            columns:
+              - column:
+                  name: user_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role
+                  type: varchar(20)
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: roles
+            baseColumnNames: user_id
+            constraintName: fk_roles_users
+            referencedTableName: users
+            referencedColumnNames: id
+        - addUniqueConstraint:
+            tableName: roles
+            columnNames: user_id, role
+            constraintName: unique_user_role

--- a/src/main/resources/db/changelog/changes/05-insert-test-users.yaml
+++ b/src/main/resources/db/changelog/changes/05-insert-test-users.yaml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+  - changeSet:
+      id: 05-insert-test-users
+      author: bereketab
+      changes:
+        - insert:
+            tableName: users
+            columns:
+              - column:
+                  name: username
+                  value: user
+              - column:
+                  name: password
+                  value: $2a$10$3zHz8Zb6Nk2g7asb0.3Q3O3o3z3y3z3y3z3y3z3y3z3y3z3y3z3y
+              - column:
+                  name: enabled
+                  valueBoolean: true
+        - insert:
+            tableName: users
+            columns:
+              - column:
+                  name: username
+                  value: admin
+              - column:
+                  name: password
+                  value: $2a$10$4aIz9Zb7Ok3h8atc1.4Q4P4p4a4p4a4p4a4p4a4p4a4p4a4p4a4p
+              - column:
+                  name: enabled
+                  valueBoolean: true
+        - insert:
+            tableName: roles
+            columns:
+              - column:
+                  name: user_id
+                  value: 1
+              - column:
+                  name: role
+                  value: ROLE_USER
+        - insert:
+            tableName: roles
+            columns:
+              - column:
+                  name: user_id
+                  value: 2
+              - column:
+                  name: role
+                  value: ROLE_ADMIN

--- a/src/main/resources/db/changelog/changes/06-add-roles-id.yaml
+++ b/src/main/resources/db/changelog/changes/06-add-roles-id.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 06-add-roles-id
+      author: bereketab
+      changes:
+        - addColumn:
+            tableName: roles
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true

--- a/src/main/resources/db/changelog/changes/07-change-admin-password.yaml
+++ b/src/main/resources/db/changelog/changes/07-change-admin-password.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 06-change-admin-password
+      author: bereketab
+      changes:
+        - update:
+            tableName: users
+            columns:
+              - column:
+                  name: password
+                  value: '$2a$10$afTgN0c.1V5mPMryPaRI9u3JIfVFjNq25sJkN90MNrY.6W3zkbbeO'   # hashed password (e.g., BCrypt)
+            where: username = 'admin'

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5,3 +5,9 @@ databaseChangeLog:
       file: db/changelog/changes/02-insert-test-data.yaml
   - include:
       file: db/changelog/changes/03-add-image-id.yaml
+  - include:
+      file: db/changelog/changes/04-create-users-roles.yaml
+  - include:
+      file: db/changelog/changes/05-insert-test-users.yaml
+  - include:
+      file: db/changelog/changes/06-add-roles-id.yaml

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -11,3 +11,5 @@ databaseChangeLog:
       file: db/changelog/changes/05-insert-test-users.yaml
   - include:
       file: db/changelog/changes/06-add-roles-id.yaml
+  - include:
+      file: db/changelog/changes/07-change-admin-password.yaml


### PR DESCRIPTION
- Added `users` and `roles` tables (`db/changelog/04-create-users-roles.yaml`, `05-insert-test-users.yaml`).
- Implemented registration (`POST /api/v1/register`) with BCrypt passwords, assigns `ROLE_USER`.
- Implemented login (`POST /api/v1/login`) with JWT (1-hour expiry, no refresh tokens).
- Secured all endpoints except `/register` and `/login` (401 Unauthorized if unauthenticated).
- Added role system (`ROLE_USER`, `ROLE_ADMIN`).
- Added admin-only endpoint `GET /api/v1/admin/test` with `@PreAuthorize` (403 for non-admins, 401 if unauthenticated).
- Updated Postman collection (`docs/LibraryAPICollection.postman_collection.json`).